### PR TITLE
Check can encrypt

### DIFF
--- a/default_organisation.bash
+++ b/default_organisation.bash
@@ -86,10 +86,13 @@ set_gpg_recipients() {
 		while read gpg_id; do
 			# Check that gpg know recipient and policy allow to encrypt for them
 			local can_encrypt=0
-			while read capab; do
-				[[ $capab =~ "e" ]] && can_encrypt=1
-			done < <($GPG --list-key --with-colons "$gpg_id" | grep "^sub" | cut -d ":" -f 12)
-			[[ $can_encrypt -eq 0 ]] && die "GPG can not encrypt for $gpg_id. Did you import it?"
+			while read sub; do
+				local trust_level=$(echo $sub | cut -d ":" -f 2)
+				local capabilities=$(echo $sub | cut -d ":" -f 12)
+				[[ $trust_level =~ [mfu] ]] && [[ $capabilities =~ "e" ]] && can_encrypt=1
+			done < <($GPG --list-key --with-colons "$gpg_id" | grep -E "^sub|^pub")
+			[[ $can_encrypt -eq 0 ]] && gpg --list-key "$gpg_id"
+			[[ $can_encrypt -eq 0 ]] && die "GPG can not encrypt for \"$gpg_id\". Did you import and trust it?"
 
 			GPG_RECIPIENT_ARGS+=( "-r" "$gpg_id" )
 			GPG_RECIPIENTS+=( "$gpg_id" )


### PR DESCRIPTION
Groups can contain fingerprint associated with keys that does not have good trust level or encryption capability. This pull request adds a check when gathering recipients to make sure that gpg will not crash.